### PR TITLE
Crate an AttackCreatureEvent whenever a player attacks a mob

### DIFF
--- a/src/main/java/kamkeel/npcdbc/NPCEventHandler.java
+++ b/src/main/java/kamkeel/npcdbc/NPCEventHandler.java
@@ -11,7 +11,7 @@ public class NPCEventHandler {
 
     @SubscribeEvent
     public void DBCAttackEvent(DBCPlayerEvent.DamagedEvent event) {
-        if (event.player == null || event.player == null || event.player.getMCEntity() == null || event.player.getMCEntity().worldObj.isRemote)
+        if (event.player == null || event.player.getMCEntity() == null || event.player.getMCEntity().worldObj.isRemote)
             return;
 
         Form form = DBCData.getForm((EntityPlayer) event.player.getMCEntity());

--- a/src/main/java/kamkeel/npcdbc/api/event/IDBCEvent.java
+++ b/src/main/java/kamkeel/npcdbc/api/event/IDBCEvent.java
@@ -2,6 +2,7 @@ package kamkeel.npcdbc.api.event;
 
 import cpw.mods.fml.common.eventhandler.Cancelable;
 import noppes.npcs.api.IDamageSource;
+import noppes.npcs.api.entity.IEntity;
 import noppes.npcs.api.event.IPlayerEvent;
 
 public interface IDBCEvent extends IPlayerEvent {
@@ -85,6 +86,41 @@ public interface IDBCEvent extends IPlayerEvent {
          * @return 0: Unknown, 1: Player, 2: NPC, 3: Ki Attack
          */
         float getType();
+    }
+
+    @Cancelable
+    interface AttackCreatureEvent extends IDBCEvent {
+
+        /**
+         * Calculated based on Player's Stats, Dex, Blocking, etc.
+         *
+         * @return Damage Dealt to the HP of the Entity
+         */
+        float getDamage();
+
+        /**
+         * Allows you to change / intercept the damage to HP
+         * and modify to set new HP.
+         *
+         * @param damage The new damage to HP
+         */
+        void setDamage(float damage);
+
+        /**
+         * @return IDamageSource
+         */
+        IDamageSource getDamageSource();
+
+        /**
+         * @return The Entity being attacked
+         */
+        public IEntity<?> getVictim();
+
+        /**
+         * @return If the victim is a CustomNPC
+         */
+        public boolean isCustomNPC();
+
     }
 
     @Cancelable

--- a/src/main/java/kamkeel/npcdbc/constants/DBCScriptType.java
+++ b/src/main/java/kamkeel/npcdbc/constants/DBCScriptType.java
@@ -4,6 +4,7 @@ public enum DBCScriptType {
 
     FORMCHANGE("dbcFormChange"),
     DAMAGED("dbcDamaged"),
+    ATTACK_CREATURE("dbcAttackCreature"),
     CAPSULEUSED("dbcCapsuleUsed"),
     REVIVED("dbcRevived"),
     KNOCKOUT("dbcKnockout");

--- a/src/main/java/kamkeel/npcdbc/scripted/DBCEventHooks.java
+++ b/src/main/java/kamkeel/npcdbc/scripted/DBCEventHooks.java
@@ -13,6 +13,13 @@ public class DBCEventHooks {
         return NpcAPI.EVENT_BUS.post(formChangeEvent);
     }
 
+    public static boolean onAttackCreatureEvent(DBCPlayerEvent.AttackCreatureEvent attackCreatureEvent) {
+        PlayerDataScript handler = ScriptController.Instance.playerScripts;
+        handler.callScript(DBCScriptType.ATTACK_CREATURE.function, attackCreatureEvent);
+        return NpcAPI.EVENT_BUS.post(attackCreatureEvent);
+    }
+
+
     public static boolean onDBCDamageEvent(DBCPlayerEvent.DamagedEvent damagedEvent) {
         PlayerDataScript handler = ScriptController.Instance.playerScripts;
         handler.callScript(DBCScriptType.DAMAGED.function, damagedEvent);

--- a/src/main/java/kamkeel/npcdbc/scripted/DBCPlayerEvent.java
+++ b/src/main/java/kamkeel/npcdbc/scripted/DBCPlayerEvent.java
@@ -9,11 +9,14 @@ import kamkeel.npcdbc.constants.DBCScriptType;
 import kamkeel.npcdbc.constants.enums.*;
 import kamkeel.npcdbc.util.PlayerDataUtil;
 import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import noppes.npcs.api.IDamageSource;
+import noppes.npcs.api.entity.IEntity;
 import noppes.npcs.api.entity.IPlayer;
+import noppes.npcs.entity.EntityNPCInterface;
 import noppes.npcs.scripted.NpcAPI;
 import noppes.npcs.scripted.event.PlayerEvent;
 
@@ -166,6 +169,51 @@ public abstract class DBCPlayerEvent extends PlayerEvent implements IDBCEvent {
 
         public String getHookName() {
             return DBCScriptType.DAMAGED.function;
+        }
+    }
+
+    @Cancelable
+    public static class AttackCreatureEvent extends DBCPlayerEvent implements IDBCEvent.AttackCreatureEvent {
+
+        public final IDamageSource damageSource;
+        public final IEntity<?> victim;
+        public float damage;
+
+        public AttackCreatureEvent(EntityPlayer player, EntityLivingBase victim, float damage, DamageSource damageSource) {
+            super(PlayerDataUtil.getIPlayer(player));
+            this.damageSource = NpcAPI.Instance().getIDamageSource(damageSource);
+            this.victim = NpcAPI.Instance().getIEntity(victim);
+            this.damage = damage;
+        }
+
+        @Override
+        public float getDamage() {
+            return damage;
+        }
+
+        @Override
+        public void setDamage(float damage){
+            this.damage = damage;
+        }
+
+        @Override
+        public IDamageSource getDamageSource() {
+            return damageSource;
+        }
+
+        @Override
+        public IEntity<?> getVictim() {
+            return victim;
+        }
+
+        @Override
+        public boolean isCustomNPC() {
+            return victim.getMCEntity() instanceof EntityNPCInterface;
+        }
+
+        @Override
+        public String getHookName() {
+            return DBCScriptType.ATTACK_CREATURE.function;
         }
     }
 


### PR DESCRIPTION
There is no way to change the damage delt from a player to a mob because dragonblock changes the behavior or LivingHurtEvent by setting the event damage to zero and applying the health manipulaiton directly.

This event allows to edit this damage before its actually delt to the entity.