### PR TITLE
Fix DBC biome decorator crash

### DIFF
--- a/src/main/java/kamkeel/npcdbc/mixins/late/NPCDBCLateMixins.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/NPCDBCLateMixins.java
@@ -83,6 +83,9 @@ public class NPCDBCLateMixins implements ILateMixinLoader {
         mixins.add("npc.MixinEntityNPCInterface");
         mixins.add("npc.MixinResistances");
 
+        // Prevent crashes from recursive biome decoration in DBC worlds
+        mixins.add("dbc.MixinBiomeDecoratorDBC");
+
         mixins.add("EDE.MixinEDEFix");
 
         return mixins;

--- a/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinBiomeDecoratorDBC.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinBiomeDecoratorDBC.java
@@ -1,0 +1,28 @@
+package kamkeel.npcdbc.mixins.late.impl.dbc;
+
+import JinRyuu.DragonBC.common.Worlds.BiomeDecoratorDBC;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Random;
+
+@Mixin(value = BiomeDecoratorDBC.class, remap = false)
+public class MixinBiomeDecoratorDBC {
+
+    /**
+     * Prevents BiomeDecoratorDBC from throwing a RuntimeException when it is
+     * called recursively by simply canceling the additional call.
+     */
+    @Inject(method = "decorateChunk", at = @At("HEAD"), cancellable = true)
+    private void cancelIfAlreadyDecorating(World world, Random random, BiomeGenBase biome, int chunkX, int chunkZ, CallbackInfo ci) {
+        BiomeDecoratorDBC self = (BiomeDecoratorDBC) (Object) this;
+        if (self.currentWorld != null) {
+            // skip decoration if another call is already running
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add mixin to skip double calls to `BiomeDecoratorDBC.decorateChunk`
- register the mixin in `NPCDBCLateMixins`

## Testing
- `./gradlew build` *(fails: decompiling large jar hangs)*

------
https://chatgpt.com/codex/tasks/task_e_686b975c21a0832396de313754e1392e