### PR TITLE
Fix server lag from invalid Ki attack positions

### DIFF
--- a/src/main/java/kamkeel/npcdbc/mixins/late/NPCDBCLateMixins.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/NPCDBCLateMixins.java
@@ -67,6 +67,7 @@ public class NPCDBCLateMixins implements ILateMixinLoader {
         mixins.add("dbc.MixinDBCPacketHandler");
         mixins.add("dbc.MixinEntityCusPar");
         mixins.add("dbc.MixinEntityEnergyAtt");
+        mixins.add("dbc.MixinEntityEnergyAttNaN");
         mixins.add("dbc.MixinJGPlayerMP");
         mixins.add("dbc.MixinJRMCoreComTickH");
         mixins.add("dbc.MixinJRMCoreEH");

--- a/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinEntityEnergyAttNaN.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinEntityEnergyAttNaN.java
@@ -1,0 +1,23 @@
+package kamkeel.npcdbc.mixins.late.impl.dbc;
+
+import JinRyuu.JRMCore.entity.EntityEnergyAtt;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = EntityEnergyAtt.class, remap = false)
+public abstract class MixinEntityEnergyAttNaN {
+
+    @Inject(method = "onUpdate", at = @At("HEAD"))
+    private void killOnInvalidPosition(CallbackInfo ci) {
+        EntityEnergyAtt self = (EntityEnergyAtt) (Object) this;
+        if (Double.isNaN(self.posX) || Double.isNaN(self.posY) || Double.isNaN(self.posZ) ||
+            Double.isInfinite(self.posX) || Double.isInfinite(self.posY) || Double.isInfinite(self.posZ) ||
+            Double.isNaN(self.motionX) || Double.isNaN(self.motionY) || Double.isNaN(self.motionZ) ||
+            Double.isInfinite(self.motionX) || Double.isInfinite(self.motionY) || Double.isInfinite(self.motionZ)) {
+            self.setDead();
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a safety mixin to kill `EntityEnergyAtt` when its coordinates become invalid
- register the mixin in the late mixin loader

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686b972f5cf48323b3b13af7c91d6789