### PR TITLE
Fix KO override logic

### DIFF
--- a/src/main/java/kamkeel/npcdbc/api/event/IDBCEvent.java
+++ b/src/main/java/kamkeel/npcdbc/api/event/IDBCEvent.java
@@ -87,6 +87,10 @@ public interface IDBCEvent extends IPlayerEvent {
          */
         void setStaminaReduced(int stamina);
 
+        /**
+         * Returns the unmodified KO result based on the current damage and
+         * attacker before any overrides are applied.
+         */
         boolean getKO();
 
         /**
@@ -96,6 +100,12 @@ public interface IDBCEvent extends IPlayerEvent {
          * @return If KO will occur
          */
         void setKo(boolean ko);
+
+        /**
+         * @return true if a knockout will ultimately occur after applying any
+         * overrides set via {@link #setKo(boolean)}
+         */
+        boolean getFinalKO();
 
         /**
          *

--- a/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinJRMCoreEH.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/impl/dbc/MixinJRMCoreEH.java
@@ -58,7 +58,7 @@ public class MixinJRMCoreEH {
         damageCalc.damage = damagedEvent.damage;
         damageCalc.stamina = damagedEvent.getStaminaReduced();
         damageCalc.ki = damagedEvent.getKiReduced();
-        damageCalc.ko = damagedEvent.getKO();
+        damageCalc.ko = damagedEvent.getFinalKO();
         DBCUtils.lastSetDamage = damageCalc;
         damageCalc.processExtras();
     }
@@ -75,7 +75,7 @@ public class MixinJRMCoreEH {
         damageCalc.damage = damagedEvent.damage;
         damageCalc.stamina = damagedEvent.getStaminaReduced();
         damageCalc.ki = damagedEvent.getKiReduced();
-        damageCalc.ko = damagedEvent.getKO();
+        damageCalc.ko = damagedEvent.getFinalKO();
         DBCUtils.lastSetDamage = damageCalc;
         damageCalc.processExtras();
     }

--- a/src/main/java/kamkeel/npcdbc/mixins/late/impl/npc/MixinDBCAddon.java
+++ b/src/main/java/kamkeel/npcdbc/mixins/late/impl/npc/MixinDBCAddon.java
@@ -99,7 +99,7 @@ public class MixinDBCAddon {
             damageCalc.damage = damagedEvent.damage;
             damageCalc.stamina = damagedEvent.getStaminaReduced();
             damageCalc.ki = damagedEvent.getKiReduced();
-            damageCalc.ko = damagedEvent.getKO();
+            damageCalc.ko = damagedEvent.getFinalKO();
             DBCUtils.lastSetDamage = damageCalc;
             damageCalc.processExtras();
             DBCUtils.doDBCDamage(player, damageCalc.damage, dbcStats, damageSource);

--- a/src/main/java/kamkeel/npcdbc/scripted/DBCPlayerEvent.java
+++ b/src/main/java/kamkeel/npcdbc/scripted/DBCPlayerEvent.java
@@ -142,13 +142,22 @@ public abstract class DBCPlayerEvent extends PlayerEvent implements IDBCEvent {
         public float damage;
         public int stamina;
         public int ki;
+        /**
+         * True if the incoming damage would knock the player out when no overrides are applied.
+         */
         public boolean ko;
+        /**
+         * Optional override applied by scripts. If null the {@code ko} value is used.
+         */
+        public Boolean koOverride;
 
         public DamagedEvent(EntityPlayer player, float damage, DamageSource damageSource, int type) {
             super(PlayerDataUtil.getIPlayer(player));
             this.damage = damage;
             this.damageSource = NpcAPI.Instance().getIDamageSource(damageSource);
             this.sourceType = type;
+            this.ko = DBCUtils.checkKnockout(player, damageSource, this.damage);
+            this.koOverride = null;
         }
 
         public DamagedEvent(EntityPlayer player, DBCDamageCalc damageCalc, DamageSource damageSource, int type) {
@@ -156,6 +165,7 @@ public abstract class DBCPlayerEvent extends PlayerEvent implements IDBCEvent {
             this.damage = damageCalc.damage;
             this.stamina = damageCalc.stamina;
             this.ko = DBCUtils.checkKnockout(player, damageSource, this.damage);
+            this.koOverride = null;
             this.ki = damageCalc.ki;
             this.damageSource = NpcAPI.Instance().getIDamageSource(damageSource);
             this.sourceType = type;
@@ -188,13 +198,24 @@ public abstract class DBCPlayerEvent extends PlayerEvent implements IDBCEvent {
         }
 
         @Override
+        /**
+         * Base KO state calculated from the player's stats and current damage
+         * without considering any overrides.
+         */
         public boolean getKO() {
             return this.ko;
         }
 
         @Override
         public void setKo(boolean ko) {
-            this.ko = ko;
+            this.koOverride = ko;
+        }
+
+        /**
+         * Returns the KO value that should be applied after taking any overrides into account.
+         */
+        public boolean getFinalKO() {
+            return this.koOverride != null ? this.koOverride : this.ko;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- allow DamagedEvent KO override without changing reported KO flag
- apply KO overrides when processing damage for players and NPCs
- expose final KO result in API

## Testing
- `bash gradlew classes`


------
https://chatgpt.com/codex/tasks/task_e_6880b0f066ec83238cd0a2674dc8c85f